### PR TITLE
release-changelog: Improve discovery of previous release tag

### DIFF
--- a/release-changelog
+++ b/release-changelog
@@ -16,7 +16,8 @@ git_fetch() {
 
 git_previous_tag() {
     local previous_tag
-    previous_tag=$(eval git tag --sort=version:refname | grep -v "$(git describe --tags)" | grep -E "${TAG_REGEX}"| tail -n1)
+    # shellcheck disable=SC2046 disable=SC2086
+    previous_tag=$(eval git tag --sort=version:refname | grep -v $(git tag --contains $(git rev-parse HEAD) | grep -E ${TAG_REGEX}) | grep -E "${TAG_REGEX}" | tail -n1)
 
     # If there is no tag, just get the first commit on repo
     [[ -z ${previous_tag} ]] && previous_tag=$(git rev-list --max-parents=0 HEAD)


### PR DESCRIPTION
When we create multiple tags for a single commit, then git describe
--tags will only return one of them (probably the latest one?)[1] and as
such the discovery of the actual release tag may fail. We can workaround
that by simply returning all the tags that match a specific commit and
then perform the first-level filtering there.

Due to the pipeline depth we need to disable some checks from shellcheck
in order to keep things working.

[1] https://stackoverflow.com/questions/8089002/git-describe-with-two-tags-on-the-same-commit
