### PR TITLE
PB-16372 Allows incrementing semver tag based on input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Produce release body
         id: git_log
-        uses: beatlabs/release-changelog-action@v0.0.1
+        uses: beatlabs/release-changelog-action@v0.0.3
         with:
           tag_regex: "v[0-9]+.[0-9]+.[0-9]+"
       - name: Create Release
@@ -34,6 +34,47 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
+          body: ${{ steps.git_log.outputs.release_body }}
+          draft: false
+          prerelease: false
+```
+
+#### Example 2
+It also allows tagging commits by incrementing semver based on the `version_bump` input. Best used in conjunction with `workflow_dispatch` event.
+
+```
+name: "production release"
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: "Version to bump (major/minor/patch)"
+        required: false
+        default: patch
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Produce release body
+        id: git_log
+        uses: beatlabs/release-changelog-action@0.0.3
+        with:
+          tag_regex: "v[0-9]+.[0-9]+.[0-9]+"
+          version_bump: ${{ github.event.inputs.version_bump }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.git_log.outputs.release_tag }}
+          release_name: ${{ steps.git_log.outputs.release_tag }}
           body: ${{ steps.git_log.outputs.release_body }}
           draft: false
           prerelease: false

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,15 @@ inputs:
     description: 'The grep regex to use for release tags'
     required: true
     default: false
+  version_bump:
+    description: 'The version (major, minor or patch) you wish to bump'
+    required: false
+    default:
 outputs:
   release_body:
     description: 'The generated changelog body'
+  release_tag:
+    description: 'The tag of the release'
 
 runs:
   using: 'docker'

--- a/release-changelog
+++ b/release-changelog
@@ -7,11 +7,16 @@ if [[ -z "${INPUT_TAG_REGEX}" ]]; then
     exit 1
 fi
 
+if [[ -z "${INPUT_VERSION_BUMP}" ]]; then
+    echo "No 'version_bump' input was specified. Skipping tagging commit."
+fi
+
 TAG_REGEX=${INPUT_TAG_REGEX}
+VERSION_BUMP=${INPUT_VERSION_BUMP}
 
 git_fetch() {
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Fetch all tags to get the previous tag in the next step.
-          git fetch --prune --unshallow                       # Fetch all history to get all commits in the release body.
+    git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Fetch all tags to get the previous tag in the next step.
+    git fetch --prune --unshallow                       # Fetch all history to get all commits in the release body.
 }
 
 git_previous_tag() {
@@ -38,9 +43,51 @@ git_generate_changelog() {
     echo ::set-output name=release_body::"## Changelog%0A${release_body}"
 }
 
+git_next_tag() {
+    local version
+    version=$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=0 --max-count=1)")
+    IFS=. read -r major minor patch <<<"$version"
+    # Remove "v" from major
+    major=${major#?}
+    case $VERSION_BUMP in
+        major)
+            ((major++))
+            minor=0
+            patch=0
+            ;;
+        minor)
+            ((minor++))
+            patch=0
+            ;;
+        patch)
+            ((patch++))
+            ;;
+        *)
+            echo -n "Version bump input can be: major, minor or patch."
+            exit 1
+            ;;
+    esac
+    printf -v version 'v%d.%d.%d' "$((major))" "$((minor))" "$((patch))"
+    echo "${version}"
+}
+
+git_tag_commit() {
+    local new_tag
+    new_tag=${1}
+    echo "Tagging latest commit with ${new_tag}"
+    git tag "${new_tag}"
+    git push origin "${new_tag}"
+}
+
+git_output_latest_tag() {
+  echo ::set-output name=release_tag::"$(git describe --abbrev=0 --tags "$(git rev-list --tags --skip=0 --max-count=1)")"
+}
+
 main() {
     git_fetch
+    [[ -n ${VERSION_BUMP} ]] && git_tag_commit "$(git_next_tag)"
     git_generate_changelog "$(git_previous_tag)"
+    git_output_latest_tag
 }
 
 main "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
We thought it would be a nice idea to create releases with a simple push of a button. So, we extended the current implementation to also tag the latest commit by incrementing the latest semver tag based on the `version_bump` input.

Now, users can also add an `workflow_dispatch` event trigger to allow this, as seen in the screenshot below

![image](https://user-images.githubusercontent.com/22637722/116245552-c26d0600-a771-11eb-8004-a05753e8622e.png)

#### Related Issues
<!--- Does this relate to any issues? -->
No related issue
