### PR TITLE
Fix workspace unsafe folder

### DIFF
--- a/release-changelog
+++ b/release-changelog
@@ -15,6 +15,7 @@ TAG_REGEX=${INPUT_TAG_REGEX}
 VERSION_BUMP=${INPUT_VERSION_BUMP}
 
 git_fetch() {
+    git config --global --add safe.directory "${GITHUB_WORKSPACE}"
     git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Fetch all tags to get the previous tag in the next step.
     git fetch --prune --unshallow                       # Fetch all history to get all commits in the release body.
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Our github release action started failing due to a recent change that may be related to https://github.blog/2022-04-12-git-security-vulnerability-announced/

The error message we got was:
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

Lots of other people also have this issue https://github.com/actions/checkout/issues/760
Tested this change on [another repo](https://github.com/stefpap/TagAction/actions/runs/2184798938) and it seems to work
